### PR TITLE
GenericLabel casts start_index and end_index to int.

### DIFF
--- a/python/nlpnewt/__init__.py
+++ b/python/nlpnewt/__init__.py
@@ -13,24 +13,24 @@
 # limitations under the License.
 """Public API and access points for the nlpnewt Framework."""
 
-from . import constants
-from . import events
-from . import label_indices
-from . import labels
-from . import processing
-from . import version
-from ._config import Config
-from ._events_service import EventsServer
-from .events import Events
-from .events import proto_label_adapter
-from .label_indices import label_index
-from .labels import GenericLabel
-from .labels import Location
-from .processing import Pipeline
-from .processing import ProcessorServer
-from .processing import processor
-from .processing import processor_parser
-from .processing import run_processor
+from nlpnewt import constants
+from nlpnewt import events
+from nlpnewt import label_indices
+from nlpnewt import labels
+from nlpnewt import processing
+from nlpnewt import version
+from nlpnewt._config import Config
+from nlpnewt._events_service import EventsServer
+from nlpnewt.events import Events
+from nlpnewt.events import proto_label_adapter
+from nlpnewt.label_indices import label_index
+from nlpnewt.labels import GenericLabel
+from nlpnewt.labels import Location
+from nlpnewt.processing import Pipeline
+from nlpnewt.processing import ProcessorServer
+from nlpnewt.processing import processor
+from nlpnewt.processing import processor_parser
+from nlpnewt.processing import run_processor
 
 __version__ = version.version
 

--- a/python/nlpnewt/_discovery.py
+++ b/python/nlpnewt/_discovery.py
@@ -16,7 +16,7 @@
 import abc
 from uuid import uuid1
 
-from . import constants
+from nlpnewt import constants
 
 
 class Discovery(abc.ABC):

--- a/python/nlpnewt/_events_service.py
+++ b/python/nlpnewt/_events_service.py
@@ -21,9 +21,9 @@ import grpc
 from grpc_health.v1 import health
 from grpc_health.v1 import health_pb2_grpc
 
-from . import constants
-from ._config import Config
-from .api.v1 import events_pb2, events_pb2_grpc
+from nlpnewt import constants
+from nlpnewt._config import Config
+from nlpnewt.api.v1 import events_pb2, events_pb2_grpc
 
 LOGGER = logging.getLogger(__name__)
 

--- a/python/nlpnewt/events.py
+++ b/python/nlpnewt/events.py
@@ -22,13 +22,13 @@ from typing import Iterator, List, Dict, MutableMapping, Mapping, Generic, TypeV
 
 import grpc
 
-from . import _discovery
-from . import _structs
-from . import constants
-from ._config import Config
-from .api.v1 import events_pb2_grpc, events_pb2
-from .label_indices import label_index, LabelIndex
-from .labels import GenericLabel, Label
+from nlpnewt import _discovery
+from nlpnewt import _structs
+from nlpnewt import constants
+from nlpnewt._config import Config
+from nlpnewt.api.v1 import events_pb2_grpc, events_pb2
+from nlpnewt.label_indices import label_index, LabelIndex
+from nlpnewt.labels import GenericLabel, Label
 
 __all__ = [
     'Events',

--- a/python/nlpnewt/examples/example_processor.py
+++ b/python/nlpnewt/examples/example_processor.py
@@ -17,7 +17,7 @@ from typing import Dict, Any, Optional
 
 import nlpnewt
 from nlpnewt.events import Document
-from nlpnewt.processing import DocumentProcessor, ProcessorContext, run_processor
+from nlpnewt.processing import DocumentProcessor, run_processor
 
 
 @nlpnewt.processor('nlpnewt-example-processor-python')

--- a/python/nlpnewt/label_indices.py
+++ b/python/nlpnewt/label_indices.py
@@ -17,7 +17,7 @@ from bisect import bisect_left, bisect_right
 from operator import attrgetter
 from typing import Union, Optional, Any, Iterator, List, TypeVar, Sequence, Generic
 
-from .labels import Label, Location
+from nlpnewt.labels import Label, Location
 
 L = TypeVar('L', bound=Label)
 

--- a/python/nlpnewt/labels.py
+++ b/python/nlpnewt/labels.py
@@ -160,11 +160,11 @@ class GenericLabel(Label, Mapping[str, Any]):
 
     @property
     def start_index(self):
-        return self.fields['start_index']
+        return int(self.fields['start_index'])
 
     @property
     def end_index(self):
-        return self.fields['end_index']
+        return int(self.fields['end_index'])
 
     def __getattr__(self, item):
         fields = self.__dict__['fields']

--- a/python/nlpnewt/processing.py
+++ b/python/nlpnewt/processing.py
@@ -29,10 +29,10 @@ from typing import List, Union, ContextManager, Any, Dict, NamedTuple, Optional,
 import grpc
 from grpc_health.v1 import health, health_pb2_grpc
 
-from . import _structs, _discovery
-from ._config import Config
-from .api.v1 import processing_pb2_grpc, processing_pb2
-from .events import Event, Document, Events
+from nlpnewt import _structs, _discovery
+from nlpnewt._config import Config
+from nlpnewt.api.v1 import processing_pb2_grpc, processing_pb2
+from nlpnewt.events import Event, Document, Events
 
 logger = logging.getLogger(__name__)
 

--- a/python/tests/test_generic_label.py
+++ b/python/tests/test_generic_label.py
@@ -136,3 +136,8 @@ def test_obj_attr():
     with pytest.raises(TypeError):
         label.b = object()
 
+
+def test_float_to_int():
+    label = GenericLabel(0.0, 4.0)
+    assert isinstance(label.start_index, int)
+    assert isinstance(label.end_index, int)


### PR DESCRIPTION
Resolves #54 by casting start_index and end_index to int.