### PR TITLE
Example of brat document conversion

### DIFF
--- a/python/nlpnewt/examples/io/__init__.py
+++ b/python/nlpnewt/examples/io/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2019 Regents of the University of Minnesota.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/python/nlpnewt/examples/io/brat_converter.py
+++ b/python/nlpnewt/examples/io/brat_converter.py
@@ -1,0 +1,72 @@
+# Copyright 2019 Regents of the University of Minnesota.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Converts brat .ann/.txt pairs into serialized events."""
+from argparse import ArgumentParser, Namespace
+from pathlib import Path
+
+from nlpnewt import Events
+from nlpnewt.io.brat import read_brat_documents
+from nlpnewt.io.serialization import get_serializer
+
+
+class BratConverter(Namespace):
+    """
+
+    Attributes
+    ----------
+    input_dir: str
+        The input directory
+    output_dir: str
+        The output directory.
+    serializer: Serializer
+        The serializer to use.
+    events_address: str
+        The address of the events service.
+    document_name: str
+        The document name to store the BRAT text and annotations.
+
+
+    """
+    def convert_files(self):
+        with Events(self.events_address) as events:
+            self.output_dir.mkdir(parents=True, exist_ok=True)
+            for event in read_brat_documents(self.input_dir, events, self.document_name,
+                                             self.label_index_name_prefix, self.input_encoding):
+                output_path = self.output_dir.joinpath(event.event_id + self.serializer.extension)
+                self.serializer.event_to_file(event, output_path)
+
+
+def main(args=None):
+    parser = ArgumentParser()
+    parser.add_argument('input_dir', type=Path,
+                        help="The input directory of BRAT .ann and .txt files")
+    parser.add_argument('output_dir', type=Path,
+                        help="The output directory of serialized files.")
+    parser.add_argument('--serializer', type=get_serializer, default='json')
+    parser.add_argument('--events-address', default=None,
+                        help='Address of the events service to use.')
+    parser.add_argument('--document-name', default='plaintext',
+                        help='The document on the event to create and read brat documents into.')
+    parser.add_argument('--label-index-name-prefix', default='',
+                        help='A string to prefix the brat annotation types before creating label '
+                             'indices.')
+    parser.add_argument('--input-encoding', default=None,
+                        help='The encoding of the input BRAT files.')
+
+    converter = parser.parse_args(args=args, namespace=BratConverter())
+    converter.convert_files()
+
+
+if __name__ == '__main__':
+    main()

--- a/python/nlpnewt/io/brat.py
+++ b/python/nlpnewt/io/brat.py
@@ -55,14 +55,16 @@ def read_brat_documents(directory: Union[Path, str],
     directory = Path(directory)
     for txt_file in directory.glob('**/*.txt'):
         yield read_brat_document(txt_file, events=events, document_name=document_name,
-                                 label_index_name_prefix=label_index_name_prefix, encoding=encoding)
+                                 label_index_name_prefix=label_index_name_prefix, encoding=encoding,
+                                 relative_to=directory)
 
 
 def read_brat_document(txt_file: Union[Path, str],
                        events: Events,
                        document_name: str = 'plaintext',
                        label_index_name_prefix: str = '',
-                       encoding: Optional[str] = None) -> Event:
+                       encoding: Optional[str] = None,
+                       relative_to: Optional[Union[Path, str]] = None) -> Event:
     """Reads a BRAT .txt and .ann file pair into an Event.
 
     Parameters
@@ -76,6 +78,9 @@ def read_brat_document(txt_file: Union[Path, str],
         A prefix to append to the brat annotation names.
     encoding: optional str
         The encoding to use when reading the files.
+    relative_to: optional str or Path
+        A str of a path or a Path object for which the event_id will be relative to, if this is
+        omitted then the file's name without extension will be used.
 
     Returns
     -------
@@ -85,7 +90,12 @@ def read_brat_document(txt_file: Union[Path, str],
     """
     txt_file = Path(txt_file)
     ann_file = txt_file.with_suffix('.ann')
-    event = events.create_event(event_id=str(txt_file))
+    if relative_to is not None:
+        relative_to = Path(relative_to)
+        event_id = str(txt_file.with_suffix('').relative_to(relative_to))
+    else:
+        event_id = txt_file.stem
+    event = events.create_event(event_id=event_id)
     with txt_file.open('r', encoding=encoding) as f:
         txt = f.read()
     document = event.add_document(document_name=document_name, text=txt)
@@ -106,7 +116,7 @@ def ann_to_labels(ann_file: Union[str, Path],
         A BRAT .ann file to load annotations from.
     document: Document
         The document to add labels to.
-     label_index_name_prefix: str
+    label_index_name_prefix: str
         A prefix to append to the brat annotation names.
     encoding: optional str
         The encoding to use when reading the ann file.

--- a/python/nlpnewt/io/json.py
+++ b/python/nlpnewt/io/json.py
@@ -38,8 +38,8 @@ class JsonSerializer(Serializer):
         try:
             self.json.dump(d, f)
         except AttributeError:
-            if isinstance(f, str):
-                f = Path(f)
+            f = Path(f)
+            f.parent.mkdir(parents=True, exist_ok=True)
             with f.open('w') as f:
                 self.json.dump(d, f)
 


### PR DESCRIPTION
Resolves #67 by adding a example utility which converts a directory of brat annotated documents to newt events.