### PR TITLE
Processor documentation via decorator

### DIFF
--- a/python/nlpnewt/__init__.py
+++ b/python/nlpnewt/__init__.py
@@ -15,27 +15,29 @@
 
 from nlpnewt import constants
 from nlpnewt import events
+from nlpnewt import io
 from nlpnewt import label_indices
 from nlpnewt import labels
 from nlpnewt import metrics
 from nlpnewt import processing
-from nlpnewt import io
 from nlpnewt import version
 from nlpnewt._config import Config
 from nlpnewt._events_service import EventsServer
-from nlpnewt.events import EventsClient
-from nlpnewt.events import Event
 from nlpnewt.events import Document
+from nlpnewt.events import Event
+from nlpnewt.events import EventsClient
 from nlpnewt.events import proto_label_adapter
 from nlpnewt.label_indices import label_index
 from nlpnewt.labels import GenericLabel
 from nlpnewt.labels import Location
-from nlpnewt.processing import RemoteProcessor
 from nlpnewt.processing import LocalProcessor
 from nlpnewt.processing import Pipeline
 from nlpnewt.processing import ProcessorServer
+from nlpnewt.processing import RemoteProcessor
+from nlpnewt.processing import label_description
 from nlpnewt.processing import processor
 from nlpnewt.processing import processor_parser
+from nlpnewt.processing import property_description
 from nlpnewt.processing import run_processor
 
 __version__ = version.version
@@ -58,11 +60,13 @@ __all__ = [
     'GenericLabel',
     'Location',
     'label_index',
-    'RemoteProcessor',
     'LocalProcessor',
+    'RemoteProcessor',
+    'label_description',
     'Pipeline',
     'processor',
     'processor_parser',
+    'property_description',
     'ProcessorServer',
     'run_processor'
 ]

--- a/python/nlpnewt/examples/example_processor.py
+++ b/python/nlpnewt/examples/example_processor.py
@@ -17,14 +17,21 @@ from typing import Dict, Any, Optional
 
 import nlpnewt
 from nlpnewt.events import Document
-from nlpnewt.processing import DocumentProcessor, run_processor
+from nlpnewt.processing import DocumentProcessor, run_processor, label_description, \
+    property_description
 
 
-@nlpnewt.processor('nlpnewt-example-processor-python')
+@nlpnewt.processor('nlpnewt-example-processor-python',
+                   description='counts the number of times the letters a and b occur in a document',
+                   outputs=[
+                       label_description('nlpnewt.examples.letter_counts',
+                                         properties=[property_description('letter', type='str'),
+                                                     property_description('count', type='int')])
+                   ])
 class ExampleProcessor(DocumentProcessor):
-    """Does some labeling of the counts of the letter 'a' and 'b' in a document, and all of the
-    times the word 'the' occurs.
+    """Does some labeling of the counts of the letter 'a' and 'b' in a document.
     """
+
     def process_document(self,
                          document: Document,
                          params: Dict[str, Any]) -> Optional[Dict[str, Any]]:

--- a/python/nlpnewt/examples/io/brat_converter.py
+++ b/python/nlpnewt/examples/io/brat_converter.py
@@ -15,13 +15,12 @@
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
 
-from nlpnewt.events import Events
 from nlpnewt.io.brat import read_brat_documents
 from nlpnewt.io.serialization import get_serializer
 
 
 class BratConverter(Namespace):
-    """
+    """Reads brat documents and writes them to a file using a serializer.
 
     Attributes
     ----------
@@ -39,13 +38,13 @@ class BratConverter(Namespace):
 
     """
     def convert_files(self):
-        with Events(self.events_address) as events:
-            self.output_dir.mkdir(parents=True, exist_ok=True)
-            for event in read_brat_documents(self.input_dir, events, self.document_name,
-                                             self.label_index_name_prefix, self.input_encoding,
-                                             self.create_indices):
-                output_path = self.output_dir.joinpath(event.event_id + self.serializer.extension)
-                self.serializer.event_to_file(event, output_path)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        for event in read_brat_documents(self.input_dir, document_name=self.document_name,
+                                         label_index_name_prefix=self.label_index_name_prefix,
+                                         encoding=self.input_encoding,
+                                         create_indices=self.create_indices):
+            output_path = self.output_dir.joinpath(event.event_id + self.serializer.extension)
+            self.serializer.event_to_file(event, output_path)
 
 
 def main(args=None):

--- a/python/nlpnewt/examples/print_processor_meta.py
+++ b/python/nlpnewt/examples/print_processor_meta.py
@@ -1,0 +1,25 @@
+# Copyright 2019 Regents of the University of Minnesota.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import sys
+
+from nlpnewt.examples.example_processor import ExampleProcessor
+from nlpnewt.processing import write_processors_metadata
+
+
+def main(filename: str):
+    write_processors_metadata(filename, ExampleProcessor)
+
+
+if __name__ == '__main__':
+    main(sys.argv[1])

--- a/python/nlpnewt/processing/__init__.py
+++ b/python/nlpnewt/processing/__init__.py
@@ -12,22 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nlpnewt.processing.base import processor
-from nlpnewt.processing.base import EventProcessor
+import nlpnewt.processing.base as base
+from nlpnewt.processing._utils import write_processors_metadata
+from nlpnewt.processing.base import AggregateTimingInfo
 from nlpnewt.processing.base import DocumentProcessor
+from nlpnewt.processing.base import EventProcessor
 from nlpnewt.processing.base import ProcessingResult
 from nlpnewt.processing.base import TimerStats
-from nlpnewt.processing.base import AggregateTimingInfo
-from nlpnewt.processing.pipeline import ProcessingComponent
-from nlpnewt.processing.pipeline import RemoteProcessor
+from nlpnewt.processing.base import label_description
+from nlpnewt.processing.base import processor
+from nlpnewt.processing.base import property_description
 from nlpnewt.processing.pipeline import LocalProcessor
 from nlpnewt.processing.pipeline import Pipeline
-from nlpnewt.processing.service import run_processor
-from nlpnewt.processing.service import processor_parser
+from nlpnewt.processing.pipeline import ProcessingComponent
+from nlpnewt.processing.pipeline import RemoteProcessor
 from nlpnewt.processing.service import ProcessorServer
+from nlpnewt.processing.service import processor_parser
+from nlpnewt.processing.service import run_processor
 
 __all__ = [
+    'base',
+    'write_processors_metadata',
     'processor',
+    'label_description',
+    'property_description',
     'EventProcessor',
     'DocumentProcessor',
     'ProcessingResult',

--- a/python/nlpnewt/processing/_utils.py
+++ b/python/nlpnewt/processing/_utils.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from pathlib import Path
+from typing import Union, Type
 
 
 def unique_component_id(component_ids, component_id):
@@ -19,3 +21,25 @@ def unique_component_id(component_ids, component_id):
     component_ids[component_id] = count
     component_id = component_id + '-' + str(count)
     return component_id
+
+
+def write_processors_metadata(output_file: Union[str, Path], *processors: Type['EventProcessor']):
+    """Writes the processor metadata as yaml to ``output_file``.
+
+    Parameters
+    ----------
+    output_file: str or Path
+        The file to write to.
+    processors: vararg type of EventProcessor
+        The EventProcessor classes to get metadata from.
+    """
+    output_file = Path(output_file)
+    arr = [processor.metadata for processor in processors]
+    from yaml import dump
+    try:
+        from yaml import CDumper as Dumper
+    except ImportError:
+        from yaml import Dumper
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    with output_file.open('w') as f:
+        dump(arr, f, Dumper=Dumper)


### PR DESCRIPTION
Resolves #46 by adding functionality to the processor decorator to add metadata information about processors. Also, contains functionality for dumping metadata for a set of processors to yaml.