### PR TITLE
Remove the component_id key from ProcessingResult.timing_info

### DIFF
--- a/python/mtap/events.py
+++ b/python/mtap/events.py
@@ -126,7 +126,7 @@ class Event:
         """~typing.Dict[str, ~typing.List[str]]: A mapping of document names to a list of the names
         of all the label indices that have been added to that document"""
         return {document_name: document.created_indices
-                for document_name, document in self._documents.items()}
+                for document_name, document in self.documents.items()}
 
     def close(self):
         """Closes this event. Lets the event service know that we are done with the event,

--- a/python/mtap/processing/pipeline.py
+++ b/python/mtap/processing/pipeline.py
@@ -282,9 +282,15 @@ class Pipeline(MutableSequence[ComponentDescriptor]):
             except AttributeError:
                 pass
 
-        return [ProcessingResult(identifier=component.component_id, results=result[0],
-                                 timing_info=result[1], created_indices=result[2])
-                for component, result in zip(self._components, results)]
+        return [
+            ProcessingResult(
+                identifier=component.component_id,
+                results=result[0],
+                timing_info={k.split(':', maxsplit=1)[-1]: v for k, v in result[1].items()},
+                created_indices=result[2]
+            )
+            for component, result in zip(self._components, results)
+        ]
 
     def processor_timer_stats(self) -> List[AggregateTimingInfo]:
         """Returns the timing information for all processors.
@@ -366,7 +372,8 @@ class Pipeline(MutableSequence[ComponentDescriptor]):
         return len(self._components)
 
     def insert(self, index, o) -> None:
-        self._components.insert(index, o.create_pipeline_component(self._config, self._component_ids))
+        self._components.insert(index,
+                                o.create_pipeline_component(self._config, self._component_ids))
 
     def __repr__(self):
         return "Pipeline(" + ', '.join(

--- a/python/tests/test_event.py
+++ b/python/tests/test_event.py
@@ -112,3 +112,8 @@ def test_documents_len(mocker):
     client.get_all_document_names.return_value = ['plaintext', 'two', 'three']
     event = Event(event_id='1', client=client)
     assert len(event.documents) == 3
+
+
+def test_created_indices_no_documents():
+    event = Event(event_id='1')
+    assert event.created_indices == {}

--- a/python/tests/test_pipeline.py
+++ b/python/tests/test_pipeline.py
@@ -1,0 +1,36 @@
+# Copyright 2019 Regents of the University of Minnesota.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from datetime import timedelta
+from typing import Dict, Any
+
+import time
+
+from mtap import Pipeline, LocalProcessor, Event
+from mtap.processing import EventProcessor
+
+
+class Processor(EventProcessor):
+    def process(self, event: Event, params: Dict[str, Any]):
+        time.sleep(0.001)
+
+
+def test_time_result():
+    processor = Processor()
+    with Pipeline(
+        LocalProcessor(processor, component_id='test_processor', client=None)
+    ) as pipeline:
+        event = Event()
+        results = pipeline.run(event)
+        result = results[0]
+        assert result.timing_info['process_method'] >= timedelta(seconds=0.001)


### PR DESCRIPTION
Bonus bug fix: accessing created_indices on event without _documents cache yet.