### PR TITLE
Fixed Metrics-related test failure

### DIFF
--- a/python/mtap/metrics.py
+++ b/python/mtap/metrics.py
@@ -27,12 +27,13 @@ __all__ = [
     'FirstTokenConfusion'
 ]
 
+from mtap.data import presorted_label_index
 from mtap.processing import DocumentProcessor, processor
 from mtap.utilities import tokenization
 
 if TYPE_CHECKING:
     import mtap
-    from mtap import data
+    from mtap import data, label_index
 
 
 class Metric(ABC):
@@ -77,7 +78,7 @@ class Metrics(DocumentProcessor):
         tested = document.labels[self.tested]
         if self.tested_filter is not None:
             tested = tested.filter(self.tested_filter)
-        target = document.labels[self.target]
+        target = document.labels.get(self.target, presorted_label_index([]))
         if self.target_filter is not None:
             target = target.filter(self.target_filter)
         local = {}

--- a/python/tests/io/test_serialization.py
+++ b/python/tests/io/test_serialization.py
@@ -27,6 +27,7 @@ def test_event_to_dict_include_label_text():
     doc = event.create_document('plaintext', text)
     doc.add_labels('sentences', [label(0, 117)])
     doc.add_labels('tokens', [label(start, end) for start, end in tokens])
+    doc.add_labels('empty_index', [])
 
     d_event = event_to_dict(event, include_label_text=True)
     d_doc = d_event['documents']['plaintext']
@@ -34,4 +35,5 @@ def test_event_to_dict_include_label_text():
     assert d_sentences['labels'][0]['_text'] == text
     d_tokens = d_doc['label_indices']['tokens']['labels']
     for i, token in enumerate(d_tokens):
-        assert token['_text'] == text[tokens[i][0]:tokens[i][1]]
+        assert token['_text'] == text[slice(*tokens[i])]
+    assert d_doc['label_indices']['empty_index']['labels'] == []


### PR DESCRIPTION
Fixes issue where tests fail when the target (gold standard) index is missing from the target document. Resolves #202 