### PR TITLE
GitHub Actions python version update

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -12,7 +12,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.5, 3.8]
+        python-version: [3.7, 3.9]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Updating to use 3.7 and 3.9 instead of 3.5 and 3.8, as new version will drop support for anything < 3.7