### PR TITLE
Reworked address file passing to revert from Java 9 to Java 8 required

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ MTAP is used to create independent, scalable, interoperable text analysis pipeli
 components in either Python or Java. 
 
 ## Requirements
-- Operating System: Ubuntu 18.04 or MacOS Catalina (other operating systems may work, but are not tested).
-- [Python 3.5+](https://www.python.org/downloads/)
-- Optional: [Java JDK 9, 11, or 13](https://adoptopenjdk.net) if you want to create Java Processors.
+- Operating System: We test on Ubuntu 20.04 and MacOS Big Sur, but other UNIX-like distributions should work.
+- [Python 3.6+](https://www.python.org/downloads/) We test on Python 3.6 and the latest stable version of Python. 
+- Optional: [Java 8+](https://adoptium.net) (_If you want to create Java Processors_) We test on Java 8 and the latest 
+  stable version of Java.
 - Optional: [Go 13+](https://golang.org) if you want to run the RESTful API Gateway.
 
 ## Features

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -8,15 +8,15 @@ plugins {
 
 def gitVersion = { ->
     def stdout = new ByteArrayOutputStream()
-    try {
-        exec {
-            commandLine 'git', 'describe', '--tags', '--dirty'
-            standardOutput = stdout
-        }
-    } catch (Exception e) {
-        // Use fallback for when the git command is not available or not in a git repo.
-        return '1.0.0+development-SNAPSHOT'
+    def execResult = exec {
+        commandLine 'git', 'describe', '--tags', '--dirty'
+        standardOutput = stdout
+        ignoreExitValue = true
     }
+    if (execResult.exitValue != 0) {
+        return '0.0.0+development-SNAPSHOT'
+    }
+
     def pattern = ~/v([0-9]+)(?:.([0-9]+))?(?:.([0-9]+))?(?:-(alpha|beta|pre|rc).([0-9]+))?(?:-([0-9]+)-([a-g0-9]+))?(-dirty)?/
     def newVersion = stdout.toString().trim().replaceFirst(pattern) { _,major,minor,patch,pre,preVersion,com,hash,dirty ->
         def incremented = false
@@ -54,7 +54,6 @@ def gitVersion = { ->
         result = "${major}${result}"
         return result
     }
-    versionFile.text = newVersion
     return newVersion
 }
 
@@ -63,8 +62,8 @@ version = gitVersion()
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_9
-    targetCompatibility = JavaVersion.VERSION_1_9
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 repositories {
@@ -73,11 +72,6 @@ repositories {
     mavenCentral()
     mavenLocal()
 }
-
-def grpcVersion = '1.+'
-def protobufVersion = '3.+'
-def junitVersion = '5.+'
-def sl4fjVersion = '1.+'
 
 java {
     withJavadocJar()
@@ -102,6 +96,11 @@ sourceSets {
         }
     }
 }
+
+def grpcVersion = '1.+'
+def protobufVersion = '3.+'
+def junitVersion = '5.+'
+def sl4fjVersion = '2.+'
 
 dependencies {
     api group: 'org.jetbrains', name: 'annotations', version: '23.+'

--- a/java/src/main/java/edu/umn/nlpie/mtap/processing/DefaultProcessorService.java
+++ b/java/src/main/java/edu/umn/nlpie/mtap/processing/DefaultProcessorService.java
@@ -37,8 +37,8 @@ public class DefaultProcessorService extends ProcessorGrpc.ProcessorImplBase imp
   private final @Nullable DiscoveryMechanism discoveryMechanism;
   private final @NotNull HealthService healthService;
 
-  private final @NotNull String processorId;
-  private final @NotNull String uniqueServiceId;
+  private final @NotNull String name;
+  private final @NotNull String sid;
 
   private final @NotNull String host;
 
@@ -51,34 +51,34 @@ public class DefaultProcessorService extends ProcessorGrpc.ProcessorImplBase imp
       @NotNull TimingService timingService,
       @Nullable DiscoveryMechanism discoveryMechanism,
       @NotNull HealthService healthService,
-      @Nullable String processorId,
-      @Nullable String uniqueServiceId,
+      @Nullable String name,
+      @Nullable String sid,
       @NotNull String host
   ) {
     this.runner = runner;
     this.timingService = timingService;
     this.discoveryMechanism = discoveryMechanism;
     this.healthService = healthService;
-    this.processorId = processorId != null ? processorId : runner.getProcessor().getProcessorName();
-    this.uniqueServiceId = uniqueServiceId != null ? uniqueServiceId : UUID.randomUUID().toString();
+    this.name = name != null ? name : runner.getProcessor().getProcessorName();
+    this.sid = sid != null ? sid : UUID.randomUUID().toString();
     this.host = host;
   }
 
   @Override
   public void started(int port) throws UnknownHostException {
     this.port = port;
-    healthService.startedServing(processorId);
+    healthService.startedServing(name);
     if (discoveryMechanism != null) {
       ServiceInfo serviceInfo = new ServiceInfo(
-          processorId,
-          uniqueServiceId,
+          name,
+          sid,
           host,
           port,
           Collections.singletonList(MTAP.PROCESSOR_SERVICE_TAG)
       );
       discoveryMechanism.register(serviceInfo);
     }
-    logger.info("Server for processor_id: {} started on port: {}", processorId, port);
+    logger.info("Server for processor_id: {} started on port: {}", name, port);
   }
 
   @Override
@@ -173,15 +173,15 @@ public class DefaultProcessorService extends ProcessorGrpc.ProcessorImplBase imp
 
   @Override
   public void close() throws InterruptedException {
-    System.out.println("Shutting down processor server with id: \"" + processorId + "\" on address: \"" + host + ":" + port + "\"");
+    System.out.println("Shutting down processor server with id: \"" + name + "\" on address: \"" + host + ":" + port + "\"");
     ServiceInfo serviceInfo = new ServiceInfo(
-        processorId,
-        uniqueServiceId,
+        name,
+        sid,
         null,
         -1,
         Collections.singletonList(MTAP.PROCESSOR_SERVICE_TAG)
     );
-    healthService.stoppedServing(processorId);
+    healthService.stoppedServing(name);
     if (discoveryMechanism != null) {
       discoveryMechanism.deregister(serviceInfo);
     }

--- a/java/src/test/java/edu/umn/nlpie/mtap/processing/ProcessorServerBuilderTest.java
+++ b/java/src/test/java/edu/umn/nlpie/mtap/processing/ProcessorServerBuilderTest.java
@@ -42,18 +42,18 @@ class ProcessorServerBuilderTest {
         "--register",
         "--port",
         "10",
-        "--identifier",
+        "--name",
         "blah",
         "--mtap-config",
         "/etc/config",
-        "--unique-service-id",
+        "--sid",
         "2");
     assertEquals("localhost:8080", options.getEventsTarget());
     assertTrue(options.getRegister());
     assertEquals(10, options.getPort());
-    assertEquals("blah", options.getIdentifier());
+    assertEquals("blah", options.getName());
     assertEquals(Paths.get("/etc/config"), options.getConfigFile());
-    assertEquals("2", options.getUniqueServiceId());
+    assertEquals("2", options.getSid());
   }
 
   @Test
@@ -95,8 +95,8 @@ class ProcessorServerBuilderTest {
 
   @Test
   void setIdentifier() {
-    options.setIdentifier("foo");
-    assertEquals("foo", options.getIdentifier());
+    options.setName("foo");
+    assertEquals("foo", options.getName());
   }
 
   @Test
@@ -109,20 +109,20 @@ class ProcessorServerBuilderTest {
         "--register",
         "--port",
         "10",
-        "--identifier",
+        "--name",
         "blah",
         "--mtap-config",
         "/etc/config",
-        "--unique-service-id",
+        "--sid",
         "2",
         "--extra",
         "foo");
     assertEquals("localhost:8080", options.getEventsTarget());
     assertTrue(options.getRegister());
     assertEquals(10, options.getPort());
-    assertEquals("blah", options.getIdentifier());
+    assertEquals("blah", options.getName());
     assertEquals(Paths.get("/etc/config"), options.getConfigFile());
-    assertEquals("2", options.getUniqueServiceId());
+    assertEquals("2", options.getSid());
     assertEquals("foo", options.extra);
   }
 

--- a/java/src/test/java/edu/umn/nlpie/mtap/processing/ProcessorServerTest.java
+++ b/java/src/test/java/edu/umn/nlpie/mtap/processing/ProcessorServerTest.java
@@ -26,6 +26,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -64,6 +65,6 @@ class ProcessorServerTest {
   }
 
   private ProcessorServer createProcessorServer(Server server) {
-    return new ProcessorServer(mockProcessorService, server, "127.0.0.1", false);
+    return new ProcessorServer(mockProcessorService, server, "127.0.0.1", UUID.randomUUID().toString(), false);
   }
 }

--- a/python/mtap/__init__.py
+++ b/python/mtap/__init__.py
@@ -23,6 +23,7 @@ from mtap.data import GenericLabel
 from mtap.data import label
 from mtap.data import label_index
 from mtap.data import Location
+from mtap.deployment import Deployment
 from mtap.processing import descriptions
 from mtap.processing import DocumentProcessor
 from mtap.processing import EventProcessor

--- a/python/mtap/__main__.py
+++ b/python/mtap/__main__.py
@@ -34,7 +34,7 @@ def run_events_server(args):
     with Config() as c:
         if args.mtap_config is not None:
             c.update_from_yaml(args.mtap_config)
-        server = EventsServer(args.host, port=args.port, register=args.register,
+        server = EventsServer(args.host, sid=args.sid, port=args.port, register=args.register,
                               workers=args.workers,
                               write_address=args.write_address)
         server.start()
@@ -65,6 +65,7 @@ def main(args=None):
                                help='the port to serve the service on')
     events_parser.add_argument('--workers', '-w', type=int, default=10,
                                help='number of worker threads to handle requests')
+    events_parser.add_argument('--sid', help='The unique service identifier for the events service.')
     events_parser.add_argument('--register', '-r', action='store_true',
                                help='whether to register the service with the configured '
                                     'service discovery')

--- a/python/mtap/_events_service.py
+++ b/python/mtap/_events_service.py
@@ -49,11 +49,12 @@ class EventsServer:
     """
 
     def __init__(self, host: str, *, port: int = 0, register: bool = False, workers: int = 10,
-                 write_address: bool = False, config: 'Optional[mtap.Config]' = None):
+                 sid: Optional[str] = None, write_address: bool = False, config: 'Optional[mtap.Config]' = None):
         if host is None:
             host = '127.0.0.1'
         if port is None:
             port = 0
+        self.sid = sid or str(uuid.uuid4())
         self.write_address = write_address
         thread_pool = ThreadPoolExecutor(max_workers=workers)
         if config is None:
@@ -86,7 +87,8 @@ class EventsServer:
         self._server.start()
         if self.write_address:
             self._address_file = utilities.write_address_file(
-                '{}:{}'.format(self._address, self.port)
+                '{}:{}'.format(self._address, self.port),
+                self.sid
             )
         if self._register:
             from mtap._discovery import Discovery

--- a/python/mtap/examples/exampleDeploymentConfiguration.yml
+++ b/python/mtap/examples/exampleDeploymentConfiguration.yml
@@ -46,14 +46,14 @@ processors:
     # For example: instances: 3 and port: 10101 will assign the ports 10101, 10102, and 10103
     # Alternatively, you can omit instances and use a list of ports here: e.g. [10101, 10102, 10103]
     port: 10101
-    # an optional identifier override.
-    identifier: null
+    # an optional processor name override.
+    name: null
     # An optional override for the number of worker threads per server.
     workers: 10
     # any arguments to be placed before the chain of processor arguments, for example a positional
     # argument for a sub-command.
     pre_args: [ ]
-    args: [ ]  # a list of additional arguments for the processor
+    additional_args: [ ]  # a list of additional arguments for the processor
     startup_timeout: 60 # Optional override for startup timeout
   - implementation: java
     entry_point: edu.umn.nlpie.mtap.examples.WordOccurrencesExampleProcessor

--- a/python/mtap/examples/examplePipelineConfiguration.yml
+++ b/python/mtap/examples/examplePipelineConfiguration.yml
@@ -17,12 +17,12 @@ mp_config:
   # Whether to close events that are handed off from the source to the pipeline.
   close_events: True
 components:
-  - processor_id: mtap-example-processor-python # The processor's identifier
+  - name: mtap-example-processor-python # The processor's identifier
     address: localhost:10101 # The address of the processor, null to use service discovery
     component_id: null
     params:
       do_work: yes
-  - processor_id: mtap-example-processor-java
+  - name: mtap-example-processor-java
     address: localhost:10102
     component_id: null
     params:

--- a/python/mtap/examples/tutorial/pipeline.py
+++ b/python/mtap/examples/tutorial/pipeline.py
@@ -19,7 +19,7 @@ if __name__ == '__main__':
 
     with EventsClient(address=sys.argv[1]) as client, \
             Pipeline(
-                RemoteProcessor(processor_id='hello', address=sys.argv[2])
+                RemoteProcessor(processor_name='hello', address=sys.argv[2])
             ) as pipeline:
         with Event(event_id='1', client=client) as event:
             document = Document(document_name='name', text='YOUR NAME')

--- a/python/tests/deployment/test_deployment.py
+++ b/python/tests/deployment/test_deployment.py
@@ -1,0 +1,54 @@
+#  Copyright 2022 Regents of the University of Minnesota.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import os.path
+
+import mtap
+import pytest
+
+
+text = """
+Why, friends, you go to do you know not what:
+Wherein hath Caesar thus deserved your loves?
+Alas, you know not: I must tell you then:
+You have forgot the will I told you of.
+…
+Here is the will, and under Caesar’s seal.
+To every Roman citizen he gives,
+To every several man, seventy-five drachmas.
+…
+Moreover, he hath left you all his walks,
+His private arbours and new-planted orchards,
+On this side Tiber; he hath left them you,
+And to your heirs for ever, common pleasures,
+To walk abroad, and recreate yourselves.
+Here was a Caesar! when comes such another?
+"""
+
+
+def test_deployment(java_exe):
+    from importlib_resources import files, as_file
+    deployment_config = files('mtap.examples').joinpath('exampleDeploymentConfiguration.yml')
+    run_config = files('mtap.examples').joinpath('examplePipelineConfiguration.yml')
+    with as_file(deployment_config) as deployment_f, as_file(run_config) as run_f:
+        deployment = mtap.Deployment.from_yaml_file(deployment_f)
+        deployment.shared_processor_config.java_classpath = java_exe[-1]
+        try:
+            deployment.run_servers(block=False)
+            pipeline = mtap.Pipeline.from_yaml_file(run_f)
+            with mtap.Event(client=pipeline.events_client) as e:
+                d = e.create_document('plaintext', text)
+                results = pipeline.run(d)
+                assert results is not None
+        finally:
+            deployment.shutdown(stop=True)

--- a/python/tests/integration/test_hello_world_tutorial.py
+++ b/python/tests/integration/test_hello_world_tutorial.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-from pathlib import Path
+import sys
 from subprocess import PIPE, STDOUT, Popen, run
 
 import pytest
@@ -30,18 +30,17 @@ def fixture_python_events():
 @pytest.fixture(name='hello_processor')
 def fixture_hello_processor(python_events, processor_watcher):
     port = find_free_port()
-    p = Popen(['python', '-m', 'mtap.examples.tutorial.hello', '-p', str(port),
+    p = Popen([sys.executable, '-m', 'mtap.examples.tutorial.hello', '-p', str(port),
                '--events', python_events], stdin=PIPE, stdout=PIPE, stderr=STDOUT)
     address = "127.0.0.1:" + str(port)
     yield from processor_watcher(address=address, process=p)
 
 
 @pytest.fixture(name='java_hello_processor')
-def fixture_java_hello_processor(python_events, processor_watcher):
-    mtap_jar = os.environ['MTAP_JAR']
+def fixture_java_hello_processor(java_exe, python_events, processor_watcher):
     port = str(find_free_port())
-    p = Popen(['java', '-cp', mtap_jar, 'edu.umn.nlpie.mtap.examples.HelloWorldExample',
-               '-p', port, '--events', python_events],
+    p = Popen(java_exe + ['edu.umn.nlpie.mtap.examples.HelloWorldExample',
+                          '-p', port, '--events', python_events],
               stdin=PIPE, stdout=PIPE, stderr=STDOUT)
     address = "127.0.0.1:" + port
     yield from processor_watcher(address=address, process=p)

--- a/python/tests/integration/test_integration.py
+++ b/python/tests/integration/test_integration.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import os
 import signal
+import sys
 import tempfile
 import time
 from pathlib import Path
@@ -21,6 +22,7 @@ from subprocess import Popen, PIPE, STDOUT, TimeoutExpired
 import pytest
 import requests
 import yaml
+
 try:
     from yaml import CDumper as Dumper
 except ImportError:
@@ -43,18 +45,16 @@ def fixture_python_events():
 @pytest.fixture(name='python_processor')
 def fixture_python_processor(python_events, processor_watcher):
     port = str(find_free_port())
-    p = Popen(['python', '-m', 'mtap.examples.example_processor', '-p', port,
+    p = Popen([sys.executable, '-m', 'mtap.examples.example_processor', '-p', port,
                '--events', python_events], stdin=PIPE, stdout=PIPE, stderr=STDOUT)
     yield from processor_watcher(address="127.0.0.1:" + port, process=p)
 
 
 @pytest.fixture(name="java_processor")
-def fixture_java_processor(python_events, processor_watcher):
-    mtap_jar = os.environ['MTAP_JAR']
+def fixture_java_processor(java_exe, python_events, processor_watcher):
     port = str(find_free_port())
-    p = Popen(['java', '-cp', mtap_jar,
-               'edu.umn.nlpie.mtap.examples.WordOccurrencesExampleProcessor',
-               '-p', port, '-e', python_events], stdin=PIPE, stdout=PIPE, stderr=STDOUT)
+    p = Popen(java_exe + ['edu.umn.nlpie.mtap.examples.WordOccurrencesExampleProcessor',
+                          '-p', port, '-e', python_events], stdin=PIPE, stdout=PIPE, stderr=STDOUT)
     yield from processor_watcher(address="127.0.0.1:" + port, process=p)
 
 

--- a/python/tests/processing/pipeline.yml
+++ b/python/tests/processing/pipeline.yml
@@ -7,7 +7,7 @@ mp_config:
   read_ahead: 4
   close_events: False
 components:
-  - processor_id: processor-1
+  - name: processor-1
     address: localhost:1234
-  - processor_id: processor-2
+  - name: processor-2
     address: localhost:5678

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ with (Path(__file__).parent / 'README.md').open(encoding='utf-8') as f:
 setup(
     name='mtap',
     use_scm_version={
-        "fallback_version": "0.0.0devel",
+        "fallback_version": "0.0.0.devel",
         "write_to": "python/mtap/version.py"
     },
     description='A framework for distributed text analysis using gRPC and microservices-based '
@@ -161,11 +161,17 @@ setup(
         'pytest',
         'pytest-mock',
         'grpcio-testing>=' + GRPC_VERSION,
-        'requests'
+        'requests',
+        'importlib-resources'
     ],
     extras_require={
         'grpc_tools': ['grpcio-tools>=' + GRPC_VERSION],
-        'tests': ['pytest-runner', 'pytest', 'grpcio-testing>=' + GRPC_VERSION, 'requests', 'pytest-mock'],
+        'tests': ['pytest-runner',
+                  'pytest',
+                  'grpcio-testing>=' + GRPC_VERSION,
+                  'requests',
+                  'pytest-mock',
+                  'importlib-resources'],
         'docs': ['sphinx', 'sphinx_rtd_theme']
     },
     cmdclass={


### PR DESCRIPTION
Also renamed identifier/processor_id to name in the context of the processor and processor_name in all other contexts to clarify it is used as a service name and avoid confusion with the unique service identifier.